### PR TITLE
fixed nomethod error.

### DIFF
--- a/lib/google_company_search.rb
+++ b/lib/google_company_search.rb
@@ -30,7 +30,7 @@ class GoogleCompanySearch
   end
 
   private 
-  def is_valid_link(link)
+  def self.is_valid_link(link)
     blacklist = ["wikipedia.org", "manta.com", "hoovers.com", "google.com", "techcrunch.com", "bbb.org", "bloomberg.com", "yellowpages.org", "yp.com", "yellowpages.com", "fda.gov", "yelp.com", "findlaw.com", "cnbc.com", "urbandictionary.com", "webcache.googleusercontent.com", "linkedin.com", "twitter.com", "facebook.com", "yellowpagesgoesgreen.com", "mapquest.com", "whereorg.com", "macraesbluebook.com", "bizjournals.com", "amfibi.directory"]
     return false if link.match(/^(http|https):\/\//) == nil
     uri = URI(link)   


### PR DESCRIPTION
Received the following error message prior to adding self.is_valid.link

/home/***/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/google_company_search-0.0.1/lib/google_company_search.rb:23:in `block in search': undefined method `is_valid_link' for GoogleCompanySearch:Class (NoMethodError)
	from /home/***/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/google_company_search-0.0.1/lib/google_company_search.rb:18:in `each'
	from /home/***/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/google_company_search-0.0.1/lib/google_company_search.rb:18:in `search'
	from input.rb:4:in `enter'
	from input.rb:8:in `<main>'

Once adding that, the issue is resolved.